### PR TITLE
Adds seconds since gateways were last seen

### DIFF
--- a/sensorpush/model_gateway.go
+++ b/sensorpush/model_gateway.go
@@ -9,9 +9,11 @@
  */
 
 package sensorpush
+
 import (
 	"time"
 )
+
 // Gateway struct for Gateway
 type Gateway struct {
 	// Date last alert was sent
@@ -23,7 +25,7 @@ type Gateway struct {
 	// Name associated with a gateway
 	Name string `json:"name,omitempty"`
 	// Gateway is paired with a bluetooth device
-	Paired string `json:"paired,omitempty"`
+	Paired bool `json:"paired,omitempty"`
 	// Samples associated with SensorPush gateway
 	Samples map[string]Sample `json:"samples,omitempty"`
 	// Version of Sensorpush software


### PR DESCRIPTION
Not sure if this is desired or implemented properly (not a go dev!), but it adds a basic metric for seconds since a gateway was last seen. This was useful to me to know how current the info from my sensors is.

Note: I had to change the type of the `Paired` field to a `bool` for it to de-serialize, which conflicts with their docs. I supposed the docs must just be out of date.